### PR TITLE
Add Band Songbook Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Outputs
 *.pdf
+
+# Cache
+*.cache

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ These instructions will get you a copy of the project up and running on your loc
 ### Resources Songbook Mode
 
 ```
-python songbook/__main__.py input.csv output.pdf
+python songbook/__main__.py --csv input.csv output.pdf
 ```
 
 The `input.csv` can be retrieved from the "Export CSV" feature on PCO's web interface.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@ One Paragraph of project description goes here
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project on a live system.
 
+## Running It
+
+### Resources Songbook Mode
+
+```
+python songbook/__main__.py input.csv output.pdf
+```
+
+The `input.csv` can be retrieved from the "Export CSV" feature on PCO's web interface.
+
+### Band Mode
+```
+python songbook/__main__.py --band output.pdf
+```
+
+Notable differences from the resources songbook mode:
+
+- Prints by letter so that we can use this with tab dividers (skips pages until a new letter can begin on a new odd-numbered page)
+- Retrieves only non-archived songs from PCO API with song codes in the format: "A000 - Title"
+
 ## Road Map
 - [x] Retrieve chords, lyrics, metadata from API
 - [x] Parse chordpro format

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+certifi==2019.9.11
+chardet==3.0.4
+fpdf==1.7.2
+idna==2.8
+requests==2.22.0
+urllib3==1.25.7

--- a/songbook/__main__.py
+++ b/songbook/__main__.py
@@ -1,15 +1,18 @@
-import sys
+import argparse
 
 import generator
 
-
 def main():
-    if len(sys.argv) != 3:
-        print('Usage: pco-songbook input.csv output.pdf')
-        return
+    parser = argparse.ArgumentParser()
+    parser.add_argument('out_file')
+    parser.add_argument('--csv', help='CSV file, required for CSV mode.')
+    parser.add_argument('--band', help='Executes band mode (no CSV required, pulls all songs from API.', action='store_true')
+    args = parser.parse_args()
 
-    generator.generate_pdf(sys.argv[1], sys.argv[2])
-
+    if args.band:
+        generator.generate_from_api(args.out_file)
+    else:
+        generator.generate_from_csv(args.csv, args.out_file)
 
 if __name__ == '__main__':
     main()

--- a/songbook/api.py
+++ b/songbook/api.py
@@ -1,6 +1,8 @@
 import json
+import re
 import requests
 
+import song
 
 # TODO: Hide these keys somewhere
 API_KEY = 'Basic MmVhYTc2NTVkYzExZDFjNzFhODI5NmQ2ODkyMmE0MTAwOTkxZDQ2NmNjYzM1ZmJhOWZjOGMxZWQyZDI5MWUxZjphMmZhZWEyNDc1MmZhMTRjYzEzM2UzNjRlMmFjM2IzMzEyYmI5OWEzYWY0ZTEyNTEzODg2NzJjZTQ4ZTNlZmYy'
@@ -31,3 +33,33 @@ def get_all_song_metadata():
         url = response['links']['next'] if 'next' in response['links'] else None
 
     return metadata
+
+def get_all_band_songs():
+    # only retrieve non-archived songs
+    url = 'https://api.planningcenteronline.com/services/v2/songs?per_page=100&where[hidden]=false'
+
+    songs = []
+    while url is not None:
+        req = requests.get(url, headers={'Authorization': API_KEY})
+        response = json.loads(req.text)
+
+        for song_data in response['data']:
+            # only allow those with song codes assigned in title
+            m = re.match('[A-Z][0-9]+.*', song_data['attributes']['title'])
+            if not m:
+                continue
+
+            ID = int(song_data['id'])
+            chords = get_song_lyrics(ID)
+
+            song_obj = song.Song(ID, song_data['attributes']['title'], chords)
+            song_obj.admin = song_data['attributes']['admin']
+            song_obj.author = song_data['attributes']['author']
+            song_obj.copyright = song_data['attributes']['copyright']
+            songs.append(song_obj)
+
+        # The API can only fetch 100 records at a time
+        # Is there a next page to load?
+        url = response['links']['next'] if 'next' in response['links'] else None
+
+    return songs

--- a/songbook/generator.py
+++ b/songbook/generator.py
@@ -10,16 +10,16 @@ import song
 def import_csv(infilename):
     songs = []
 
-    with open(infilename, 'rb') as csvfile:
+    with open(infilename, 'r') as csvfile:
         csvreader = csv.reader(csvfile)
 
         # Skip first row header
-        csvreader.next()
+        next(csvreader)
 
         for row in csvreader:
             ID = int(row[0])
             title = row[1]
-            lyrics = row[15] if row[15] else api.get_song_lyrics(ID)
+            lyrics = row[16] if row[16] else api.get_song_lyrics(ID)
             if lyrics is None:
                 print('Skipping song with no lyrics:', title)
                 continue

--- a/songbook/generator.py
+++ b/songbook/generator.py
@@ -1,10 +1,11 @@
 from __future__ import print_function
 import csv
+import os
+import pickle
 
 import api
 import output
 import song
-
 
 def import_csv(infilename):
     songs = []
@@ -27,9 +28,9 @@ def import_csv(infilename):
 
     return songs
 
-def generate_pdf(infilename, outfilename):
-    # Retreive and ingest the song data
-    print('Importing songs...')
+def generate_from_csv(infilename, outfilename):
+    # Retrieve and ingest the song data
+    print('Importing songs from CSV...')
     songs = import_csv(infilename)
 
     # Attach metadata to songs
@@ -48,5 +49,24 @@ def generate_pdf(infilename, outfilename):
     print('Generating output...')
     book = output.SongbookPDF()
     book.print_songbook(songs)
+    book.output(outfilename)
+    print('Wrote output to', outfilename)
+
+def generate_from_api(outfilename):
+    cache_path = 'songs.cache'
+    if os.path.exists(cache_path):
+        print('Loading all non-archived, code-assigned songs from cache...')
+        songs = pickle.load(open(cache_path, 'rb'))
+    else:
+        print('Importing all non-archived, code-assigned songs from API...')
+        songs = api.get_all_band_songs()
+        pickle.dump(songs, open(cache_path, 'wb'))
+        print('Cached downloaded songs in <{}>.'.format(cache_path))
+
+    songs = sorted(songs, key=lambda s: s.title)
+
+    print('Generating output...')
+    book = output.SongbookPDF()
+    book.print_songbook_by_letter(songs)
     book.output(outfilename)
     print('Wrote output to', outfilename)

--- a/songbook/layout.py
+++ b/songbook/layout.py
@@ -13,6 +13,12 @@ class SongbookOrganizer:
         }
         self.vacant = deque()
 
+    def add_until_odd_page(self):
+        self.add_page()
+
+        if len(self.pages) % 2 == 0:
+            self.add_page()
+
     def add_page(self):
         self.pages.append(dict(self.layout))
         self.vacant.clear()

--- a/songbook/output.py
+++ b/songbook/output.py
@@ -21,6 +21,7 @@ META_FONT = 'Arial'
 FOOTER_SIZE = 8
 FOOTER_FONT = 'Arial'
 
+GUTTER_SIZE = 15
 MARGIN_SIZE = 22.6772
 INNER_BORDER = 11.3386
 INDENT_SIZE = 8.50394
@@ -54,9 +55,17 @@ class SongbookPDF(fpdf.FPDF):
             permission = 'Used by permission CCLI#1194926'
             self.cell(0, self.font_size, permission, align='R')
 
+    def add_page_with_gutter(self):
+        self.add_page()
+        next_page_odd = self.page_no() % 2 == 1
+        if next_page_odd:
+            self.set_margins(MARGIN_SIZE + GUTTER_SIZE, MARGIN_SIZE, MARGIN_SIZE - GUTTER_SIZE)
+        else:
+            self.set_margins(MARGIN_SIZE - GUTTER_SIZE, MARGIN_SIZE, MARGIN_SIZE + GUTTER_SIZE)
+
     def print_table_of_contents(self):
         pages = self.organizer.pages
-        self.add_page()
+        self.add_page_with_gutter()
 
         self.set_font(TITLE_FONT, 'B', TITLE_SIZE)
         self.cell(0, TITLE_SIZE, 'Table of Contents', border='B', align='C')
@@ -75,15 +84,22 @@ class SongbookPDF(fpdf.FPDF):
                     self.ln(LYRIC_SIZE * 1.5)
 
         self.set_auto_page_break(False, MARGIN_SIZE)
-        self.add_page()
+        self.add_page_with_gutter()
 
     def get_start_point(self, quadrant):
+        odd = self.page_no() % 2 == 1
+        left_edge = None
+        if odd:
+            left_edge = MARGIN_SIZE + GUTTER_SIZE
+        else:
+            left_edge = MARGIN_SIZE - GUTTER_SIZE
+
         if quadrant is 0:  # top left
-            return (MARGIN_SIZE, MARGIN_SIZE)
+            return (left_edge, MARGIN_SIZE)
         elif quadrant is 1:  # top right
             return (self.w / 2, MARGIN_SIZE)
         elif quadrant is 2:  # bottom left
-            return (MARGIN_SIZE, self.h / 2)
+            return (left_edge, self.h / 2)
         elif quadrant is 3:  # bottom right
             return (self.w / 2, self.h / 2)
         else:
@@ -281,7 +297,7 @@ class SongbookPDF(fpdf.FPDF):
             for i in range(4):
                 if page[i]:
                     self.print_song(page[i], i, song_sizes[page[i].pco_id])
-            self.add_page()
+            self.add_page_with_gutter()
 
     def print_songbook_by_letter(self, songs):
         # Assign songs to locations
@@ -297,7 +313,7 @@ class SongbookPDF(fpdf.FPDF):
 
             last_song_letter = song.title[0]
 
-        self.add_page()
+        self.add_page_with_gutter()
         self.printing_songs = True
 
         # Print songs in respective locations
@@ -306,4 +322,4 @@ class SongbookPDF(fpdf.FPDF):
             for i in range(4):
                 if page[i]:
                     self.print_song(page[i], i, song_sizes[page[i].pco_id], part_titles=True)
-            self.add_page()
+            self.add_page_with_gutter()

--- a/songbook/output.py
+++ b/songbook/output.py
@@ -262,3 +262,30 @@ class SongbookPDF(fpdf.FPDF):
                 if page[i]:
                     self.print_song(page[i], i, song_sizes[page[i].pco_id])
             self.add_page()
+
+    def print_songbook_by_letter(self, songs):
+        # Assign songs to locations
+        song_sizes = {}
+        last_song_letter = None
+        for song in songs:
+            letter_changed = last_song_letter is not None and song.title[0] != last_song_letter
+            if letter_changed:
+                self.organizer.add_until_odd_page()
+            size, overflow = self.get_size_and_overflow(song)
+            song_sizes[song.pco_id] = size
+            self.organizer.insert_song(song, overflow)
+
+            last_song_letter = song.title[0]
+
+        # TODO: don't print table of contents
+        # self.print_table_of_contents()
+        self.add_page()
+        self.printing_songs = True
+
+        # Print songs in respective locations
+        for page in self.organizer.pages:
+            self.current_page += 1
+            for i in range(4):
+                if page[i]:
+                    self.print_song(page[i], i, song_sizes[page[i].pco_id])
+            self.add_page()

--- a/songbook/output.py
+++ b/songbook/output.py
@@ -5,7 +5,7 @@ TITLE_SIZE = 12
 TITLE_FONT = 'Arial'
 START_MARGIN = 2
 
-PART_TITLE_SIZE = 7
+PART_TITLE_SIZE = 9
 PART_TITLE_FONT = 'Arial'
 PART_TITLE_MARGIN = 1
 
@@ -24,6 +24,7 @@ FOOTER_FONT = 'Arial'
 GUTTER_SIZE = 15
 MARGIN_SIZE = 22.6772
 INNER_BORDER = 11.3386
+SONG_WIDTH_BUFFER = 15
 INDENT_SIZE = 8.50394
 INDENT_PARTS = [
     'pre-chorus',
@@ -55,17 +56,9 @@ class SongbookPDF(fpdf.FPDF):
             permission = 'Used by permission CCLI#1194926'
             self.cell(0, self.font_size, permission, align='R')
 
-    def add_page_with_gutter(self):
-        self.add_page()
-        next_page_odd = self.page_no() % 2 == 1
-        if next_page_odd:
-            self.set_margins(MARGIN_SIZE + GUTTER_SIZE, MARGIN_SIZE, MARGIN_SIZE - GUTTER_SIZE)
-        else:
-            self.set_margins(MARGIN_SIZE - GUTTER_SIZE, MARGIN_SIZE, MARGIN_SIZE + GUTTER_SIZE)
-
     def print_table_of_contents(self):
         pages = self.organizer.pages
-        self.add_page_with_gutter()
+        self.add_page()
 
         self.set_font(TITLE_FONT, 'B', TITLE_SIZE)
         self.cell(0, TITLE_SIZE, 'Table of Contents', border='B', align='C')
@@ -84,7 +77,7 @@ class SongbookPDF(fpdf.FPDF):
                     self.ln(LYRIC_SIZE * 1.5)
 
         self.set_auto_page_break(False, MARGIN_SIZE)
-        self.add_page_with_gutter()
+        self.add_page()
 
     def get_start_point(self, quadrant):
         odd = self.page_no() % 2 == 1
@@ -127,6 +120,9 @@ class SongbookPDF(fpdf.FPDF):
                     lyrics_size += (index_count * INDENT_SIZE)
                 if lyrics_size > song_width:
                     song_width = lyrics_size
+
+        # in case chords run beyond the lyrics
+        song_width += SONG_WIDTH_BUFFER
 
         size = LYRIC_SIZE
         max_width = (self.w / 2) - MARGIN_SIZE - INNER_BORDER
@@ -300,7 +296,7 @@ class SongbookPDF(fpdf.FPDF):
             for i in range(4):
                 if page[i]:
                     self.print_song(page[i], i, song_sizes[page[i].pco_id])
-            self.add_page_with_gutter()
+            self.add_page()
 
     def print_songbook_by_letter(self, songs):
         # Assign songs to locations
@@ -316,7 +312,7 @@ class SongbookPDF(fpdf.FPDF):
 
             last_song_letter = song.title[0]
 
-        self.add_page_with_gutter()
+        self.add_page()
         self.printing_songs = True
 
         # Print songs in respective locations
@@ -325,4 +321,4 @@ class SongbookPDF(fpdf.FPDF):
             for i in range(4):
                 if page[i]:
                     self.print_song(page[i], i, song_sizes[page[i].pco_id], part_titles=True)
-            self.add_page_with_gutter()
+            self.add_page()

--- a/songbook/output.py
+++ b/songbook/output.py
@@ -88,20 +88,23 @@ class SongbookPDF(fpdf.FPDF):
 
     def get_start_point(self, quadrant):
         odd = self.page_no() % 2 == 1
-        left_edge = None
+        left_edge = MARGIN_SIZE
+        left_halfway = self.w / 2
         if odd:
-            left_edge = MARGIN_SIZE + GUTTER_SIZE
+            left_edge += GUTTER_SIZE
+            left_halfway += GUTTER_SIZE
         else:
-            left_edge = MARGIN_SIZE - GUTTER_SIZE
+            left_edge -= GUTTER_SIZE
+            left_halfway -= GUTTER_SIZE
 
         if quadrant is 0:  # top left
             return (left_edge, MARGIN_SIZE)
         elif quadrant is 1:  # top right
-            return (self.w / 2, MARGIN_SIZE)
+            return (left_halfway, MARGIN_SIZE)
         elif quadrant is 2:  # bottom left
             return (left_edge, self.h / 2)
         elif quadrant is 3:  # bottom right
-            return (self.w / 2, self.h / 2)
+            return (left_halfway, self.h / 2)
         else:
             raise ValueError('Invalid quadrant: ' + str(self.quadrant))
 

--- a/songbook/song.py
+++ b/songbook/song.py
@@ -11,10 +11,12 @@ VALID_PARTS = [
     'tag',
     'interlude',
     'instrumental',
+    'vamp',
     'outro'
 ]
 IGNORE_LINES = [
-    'column_break',
+    'transpose key',
+    'column_break'
 ]
 
 # A single line of lyrics and chords in a song
@@ -28,9 +30,10 @@ class ChordLyric:
         self.chords = re.findall(CHORD_MARKER, line)
         self.lyrics = re.sub(CHORD_MARKER, '\n', line).split('\n')
 
+        # clean up HTML tag annotations in chord blocks
+        self.chords = [re.sub(r'<[/A-Za-z]+>', '', c) for c in self.chords]
     def is_empty(self):
         return not self.chords and self.lyrics == ['']
-
 
 class Song:
 
@@ -81,7 +84,7 @@ class Song:
                     chord_data.append((label, chord_lyrics))
                 chord_lyrics = []
                 label = line
-            elif any(tag not in line.lower() for tag in IGNORE_LINES):
+            elif all(tag not in line.lower() for tag in IGNORE_LINES):
                 chord_lyrics.append(ChordLyric(line))
         chord_data.append((label, chord_lyrics))
 

--- a/songbook/song.py
+++ b/songbook/song.py
@@ -72,6 +72,9 @@ class Song:
         label = ''
         chord_lyrics = []
         for line in lines:
+            # replace curly single/double quotes
+            line = line.replace(u"\u2018", "'").replace(u"\u2019", "'").replace(u"\u201c", '"').replace(u"\u201d", '"')
+
             line = ''.join((c for c in line if ord(c) < 128))
             if Song.contains_label(line.strip()):
                 if chord_lyrics or label:


### PR DESCRIPTION
Added a new mode for band songbook. Tried not to modify original features at all.

In `--band` mode it will print part titles (e.g. Verse 1, Verse 2, etc.), not indent anything, auto download relevant song list from PCO API, make sure to start every letter batch of songs on a new odd page (so as to allow the use of A-Z tab dividers in a binder). 

Bonus fixes:
- Added "gutter" for 3-hole punching, i.e increased left margin on odd pages and increased right margin on even pages
- Replaced curly single/double quotes with a hacky `replace` approach
- cleans up additional "TRANSPOSE KEY" tag in some songs